### PR TITLE
fix: efactor Stripe checkout return route parameter

### DIFF
--- a/src/app/(frontend)/(fce-form)/checkout-return/route.ts
+++ b/src/app/(frontend)/(fce-form)/checkout-return/route.ts
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Stripe } from 'stripe'
 
 if (!process.env.STRIPE_SECRET_KEY) {
@@ -8,7 +8,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY)
 
-export const GET = async (request: NextRequest, _response: NextResponse) => {
+export const GET = async (request: NextRequest) => {
   const { searchParams } = new URL(request.url)
 
   const stripeSessionId = searchParams.get('session_id')

--- a/src/app/(frontend)/(fce-form)/checkout-return/route.ts
+++ b/src/app/(frontend)/(fce-form)/checkout-return/route.ts
@@ -8,7 +8,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY)
 
-export const GET = async (request: NextRequest, response: NextResponse) => {
+export const GET = async (request: NextRequest, _response: NextResponse) => {
   const { searchParams } = new URL(request.url)
 
   const stripeSessionId = searchParams.get('session_id')


### PR DESCRIPTION
- Remove unused response parameter in GET function
- Use underscore prefix for unused parameter to indicate intentional non-use
- Improve code clarity by removing unnecessary parameter