### PR TITLE
fix: Format paid timestamp on server-side to prevent hydration errors

### DIFF
--- a/src/app/(frontend)/(aet-app)/checkout/success/page.tsx
+++ b/src/app/(frontend)/(aet-app)/checkout/success/page.tsx
@@ -44,7 +44,17 @@ const SuccessPage = async ({ searchParams }: SuccessPageProps) => {
     return notFound()
   }
 
-  return <SuccessMessage applicationData={applicationData} applicationId={applicationId} />
+  // Render in server side to avoid Hydration failed in Production
+  const formattedPaidAt = applicationData.paid_at
+    ? new Date(applicationData.paid_at).toLocaleString()
+    : null
+
+  return (
+    <SuccessMessage
+      applicationData={{ ...applicationData, paid_at: formattedPaidAt }}
+      applicationId={applicationId}
+    />
+  )
 }
 
 export default SuccessPage

--- a/src/app/(frontend)/(aet-app)/components/Checkout/SuccessMessage.tsx
+++ b/src/app/(frontend)/(aet-app)/components/Checkout/SuccessMessage.tsx
@@ -14,7 +14,6 @@ export function SuccessMessage({ applicationData, applicationId }: SuccessMessag
   console.log('Paid At:', applicationData.paid_at)
   console.log('Payment Status:', applicationData.payment_status)
   console.log('Name:', applicationData.name)
-  const paidAt = new Date(applicationData.paid_at).toLocaleString()
 
   return (
     <div className="text-center max-w-2xl mx-auto p-6">
@@ -35,16 +34,10 @@ export function SuccessMessage({ applicationData, applicationId }: SuccessMessag
             {applicationData.payment_status}
           </span>
         </p>
-        {/*
-         *  If directly use 'new Date(applicationData.paid_at).toLocaleString()'
-         *  or 'paidAt.toLocaleString()', it will make Hydration failed in Production.
-         *  So we need to make the process happen before return to avoid this issue.
-         */}
+
         <p className="text-gray-600">
           Paid At:{' '}
-          <span className="font-semibold">
-            {applicationData.paid_at ? paidAt : 'Processing...'}
-          </span>
+          <span className="font-semibold">{applicationData.paid_at || 'Processing...'}</span>
         </p>
       </Card>
       <p className="text-sm text-gray-500 mb-4">


### PR DESCRIPTION
- Move date localization to server-side rendering in SuccessPage
- Remove local date formatting in SuccessMessage component
- Simplify paid timestamp rendering logic