### PR TITLE
fix: Update Stripe configuration for client-side compatibility

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server'
-import { stripe, STRIPE_CONFIG } from '../../../utils/stripe/config'
+import { stripe, getStripeConfig } from '../../../utils/stripe/config'
 
 export async function POST(request: Request) {
+  const stripeConfig = await getStripeConfig()
   try {
     const body = await request.json()
     const { amount, currency } = body
@@ -31,7 +32,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ url: session.url })
   } catch (error) {
-    console.error(`${STRIPE_CONFIG.mode} payment creation error:`, error)
+    console.error(`${stripeConfig.mode} payment creation error:`, error)
 
     // Handle Stripe errors
     if (error instanceof stripe.errors.StripeError) {
@@ -40,7 +41,7 @@ export async function POST(request: Request) {
           error: error.message || 'Payment processing failed',
           code: error.code,
           type: error.type,
-          mode: STRIPE_CONFIG.mode,
+          mode: stripeConfig.mode,
         },
         { status: error.statusCode || 400 }
       )
@@ -50,7 +51,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error: 'Internal server error',
-        mode: STRIPE_CONFIG.mode,
+        mode: stripeConfig.mode,
       },
       { status: 500 }
     )

--- a/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server'
-import { stripe, getStripeConfig } from '../../../utils/stripe/config'
+import { Stripe } from 'stripe'
+import { getStripeConfig } from '../../../utils/stripe/config'
 
 export async function POST(request: Request) {
   const stripeConfig = await getStripeConfig()
+  const stripe = new Stripe(stripeConfig.secretKey)
+
   try {
     const body = await request.json()
     const { amount, currency } = body

--- a/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
@@ -2,12 +2,14 @@ import { headers } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { Stripe } from 'stripe'
 import { createClient } from '../../../utils/supabase/server'
-import { stripe, getStripeConfig } from '../../../utils/stripe/config'
+import { getStripeConfig } from '../../../utils/stripe/config'
 
 export async function POST(req: Request) {
-  const stripeConfig = await getStripeConfig()
   const body = await req.text()
   const signature = (await headers()).get('stripe-signature')
+
+  const stripeConfig = await getStripeConfig()
+  const stripe = new Stripe(stripeConfig.secretKey)
 
   if (!signature) {
     return new NextResponse('No signature', { status: 400 })

--- a/src/app/(frontend)/(aet-app)/checkout/return/route.ts
+++ b/src/app/(frontend)/(aet-app)/checkout/return/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { stripe, getStripeConfig } from '../../utils/stripe/config'
+import { Stripe } from 'stripe'
+import { getStripeConfig } from '../../utils/stripe/config'
 
 export const GET = async (request: NextRequest) => {
   const { searchParams } = new URL(request.url)
   const stripeSessionId = searchParams.get('session_id')
+
   const stripeConfig = await getStripeConfig()
+  const stripe = new Stripe(stripeConfig.secretKey)
 
   if (!stripeSessionId?.length) {
     const error = `${stripeConfig.mode} mode: Missing session_id in return URL`

--- a/src/app/(frontend)/(aet-app)/checkout/return/route.ts
+++ b/src/app/(frontend)/(aet-app)/checkout/return/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { stripe, STRIPE_CONFIG } from '../../utils/stripe/config'
+import { stripe, getStripeConfig } from '../../utils/stripe/config'
 
 export const GET = async (request: NextRequest) => {
   const { searchParams } = new URL(request.url)
   const stripeSessionId = searchParams.get('session_id')
+  const stripeConfig = await getStripeConfig()
 
   if (!stripeSessionId?.length) {
-    const error = `${STRIPE_CONFIG.mode} mode: Missing session_id in return URL`
+    const error = `${stripeConfig.mode} mode: Missing session_id in return URL`
     console.error(error)
     return NextResponse.json({ error }, { status: 400 })
   }
@@ -17,7 +18,7 @@ export const GET = async (request: NextRequest) => {
     if (session.status === 'complete') {
       // Get application id from session metadata and redirect to success page with it
       const applicationId = session.metadata?.applicationId
-      console.log(`${STRIPE_CONFIG.mode} mode: Payment completed for application:`, applicationId)
+      console.log(`${stripeConfig.mode} mode: Payment completed for application:`, applicationId)
       return NextResponse.redirect(
         new URL(`/checkout/success?applicationId=${applicationId}`, request.url)
       )
@@ -26,15 +27,15 @@ export const GET = async (request: NextRequest) => {
     if (session.status === 'open') {
       // Here you'll likely want to head back to some pre-payment page in your checkout
       // so the user can try again
-      console.log(`${STRIPE_CONFIG.mode} mode: Session still open, redirecting to checkout`)
+      console.log(`${stripeConfig.mode} mode: Session still open, redirecting to checkout`)
       return NextResponse.redirect(new URL('/checkout', request.url))
     }
 
-    const error = `${STRIPE_CONFIG.mode} mode: Unexpected session status: ${session.status}`
+    const error = `${stripeConfig.mode} mode: Unexpected session status: ${session.status}`
     console.error(error)
     return NextResponse.json({ error }, { status: 400 })
   } catch (error) {
-    const errorMessage = `${STRIPE_CONFIG.mode} mode: Error retrieving session: ${
+    const errorMessage = `${stripeConfig.mode} mode: Error retrieving session: ${
       error instanceof Error ? error.message : 'Unknown error'
     }`
     console.error(errorMessage)

--- a/src/app/(frontend)/(aet-app)/components/CheckoutForm.tsx
+++ b/src/app/(frontend)/(aet-app)/components/CheckoutForm.tsx
@@ -2,9 +2,9 @@
 
 import { useCallback } from 'react'
 import { EmbeddedCheckoutProvider, EmbeddedCheckout } from '@stripe/react-stripe-js'
-
+import { loadStripe } from '@stripe/stripe-js'
 import { postStripeSession } from '../utils/stripe/session'
-import { stripePromise } from '../utils/stripe/config'
+import { getStripeConfig } from '../utils/stripe/config'
 
 export const CheckoutForm = ({
   priceId,
@@ -13,6 +13,7 @@ export const CheckoutForm = ({
   priceId: string
   applicationId: string
 }) => {
+  // Elegantly fetch the client secret in a synchronous function
   const fetchClientSecret = useCallback(async () => {
     const stripeResponse = await postStripeSession({
       priceId,
@@ -22,6 +23,14 @@ export const CheckoutForm = ({
   }, [priceId, applicationId])
 
   const options = { fetchClientSecret }
+
+  const fetchStripePromise = useCallback(async () => {
+    const stripeConfig = await getStripeConfig()
+    const stripePromise = loadStripe(stripeConfig.publishableKey)
+    return stripePromise
+  }, [])
+
+  const stripePromise = fetchStripePromise()
 
   return (
     <div id="checkout">

--- a/src/app/(frontend)/(aet-app)/components/Stripe/InlinePricing.tsx
+++ b/src/app/(frontend)/(aet-app)/components/Stripe/InlinePricing.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { useToast } from '@/hooks/use-toast'
-import { STRIPE_CONFIG } from '../../utils/stripe/config'
 
 export default function StripeInlinePricing() {
   // Use string type for amount to better handle input
@@ -59,7 +58,8 @@ export default function StripeInlinePricing() {
 
   return (
     <div className="max-w-md mx-auto">
-      {STRIPE_CONFIG.mode === 'test' && (
+      {/* Cannot use server side env variables in client side code */}
+      {!(process.env.NODE_ENV === 'production') && (
         <div className="bg-yellow-100 border-l-4 border-yellow-500 p-4 mb-4">
           <p className="text-yellow-700">
             Warning: Stripe is in test mode. Use test card numbers only.

--- a/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
@@ -1,11 +1,8 @@
 'use server'
 
-import Stripe from 'stripe'
-import { loadStripe } from '@stripe/stripe-js'
 // It works well in test mode
 // const isProduction = false
 const isProduction = process.env.NODE_ENV === 'production'
-const STRIPE_MODE = isProduction ? 'live' : 'test'
 
 // Choose the correct API key based on the environment
 const stripeSecretKey = isProduction
@@ -17,33 +14,36 @@ const stripePublishableKey = isProduction
   : process.env.STRIPE_TEST_PUBLISHABLE_KEY!
 
 // Get the correct webhook secret based on the environment
-const webhookSecret = isProduction
+const stripeWebhookSecret = isProduction
   ? process.env.STRIPE_LIVE_WEBHOOK_SECRET!
   : process.env.STRIPE_TEST_WEBHOOK_SECRET!
 
-if (!stripeSecretKey) {
-  throw new Error(
-    `${process.env.NODE_ENV}:\n  Stripe ${STRIPE_MODE} Mode: secret key is not configured`
-  )
-}
-
-export const stripe = new Stripe(stripeSecretKey)
-
-if (!stripePublishableKey) {
-  throw new Error(
-    `${process.env.NODE_ENV}:\n  Stripe ${STRIPE_MODE} Mode: publishable key is not configured`
-  )
-}
-
-export const stripePromise = loadStripe(stripePublishableKey)
-
 export async function getStripeConfig() {
-  const isProduction = process.env.NODE_ENV === 'production'
   const STRIPE_MODE = isProduction ? 'live' : 'test'
+
+  if (!stripeSecretKey) {
+    throw new Error(
+      `${process.env.NODE_ENV}:\n  Stripe ${STRIPE_MODE} Mode: secret key is not configured`
+    )
+  }
+
+  if (!stripePublishableKey) {
+    throw new Error(
+      `${process.env.NODE_ENV}:\n  Stripe ${STRIPE_MODE} Mode: publishable key is not configured`
+    )
+  }
+
+  if (!stripeWebhookSecret) {
+    throw new Error(
+      `${process.env.NODE_ENV}:\n  Stripe ${STRIPE_MODE} Mode: webhook secret is not configured`
+    )
+  }
 
   const stripeConfig = {
     mode: STRIPE_MODE,
-    webhookSecret,
+    secretKey: stripeSecretKey,
+    publishableKey: stripePublishableKey,
+    webhookSecret: stripeWebhookSecret,
   } as const
 
   return stripeConfig

--- a/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
@@ -1,8 +1,11 @@
+'use server'
+
 import Stripe from 'stripe'
 import { loadStripe } from '@stripe/stripe-js'
 // It works well in test mode
 // const isProduction = false
 const isProduction = process.env.NODE_ENV === 'production'
+export const STRIPE_MODE = isProduction ? 'live' : 'test'
 
 // Choose the correct API key based on the environment
 const stripeSecretKey = isProduction
@@ -14,27 +17,26 @@ const stripePublishableKey = isProduction
   : process.env.STRIPE_TEST_PUBLISHABLE_KEY!
 
 // Get the correct webhook secret based on the environment
-const webhookSecret = isProduction
+export const webhookSecret = isProduction
   ? process.env.STRIPE_LIVE_WEBHOOK_SECRET!
   : process.env.STRIPE_TEST_WEBHOOK_SECRET!
 
-export const STRIPE_MODE = isProduction ? 'live' : 'test'
-
 if (!stripeSecretKey) {
-  throw new Error(`Stripe ${STRIPE_MODE} secret key is not configured`)
+  throw new Error(
+    `${process.env.NODE_ENV}:\n  Stripe ${STRIPE_MODE} Mode: secret key is not configured`
+  )
 }
 
 export const stripe = new Stripe(stripeSecretKey)
 
 if (!stripePublishableKey) {
-  throw new Error(`Stripe ${STRIPE_MODE} publishable key is not configured`)
+  throw new Error(`Stripe ${STRIPE_MODE} Mode: publishable key is not configured`)
 }
 
 export const stripePromise = loadStripe(stripePublishableKey)
 
-// Export webhook configuration
 export const STRIPE_CONFIG = {
   mode: STRIPE_MODE,
-  webhookSecret,
   publishableKey: stripePublishableKey,
+  webhookSecret,
 } as const

--- a/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
@@ -41,10 +41,10 @@ export async function getStripeConfig() {
   const isProduction = process.env.NODE_ENV === 'production'
   const STRIPE_MODE = isProduction ? 'live' : 'test'
 
-  const STRIPE_CONFIG = {
+  const stripeConfig = {
     mode: STRIPE_MODE,
     webhookSecret,
   } as const
 
-  return STRIPE_CONFIG
+  return stripeConfig
 }

--- a/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
@@ -5,7 +5,7 @@ import { loadStripe } from '@stripe/stripe-js'
 // It works well in test mode
 // const isProduction = false
 const isProduction = process.env.NODE_ENV === 'production'
-export const STRIPE_MODE = isProduction ? 'live' : 'test'
+const STRIPE_MODE = isProduction ? 'live' : 'test'
 
 // Choose the correct API key based on the environment
 const stripeSecretKey = isProduction

--- a/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/config.ts
@@ -17,7 +17,7 @@ const stripePublishableKey = isProduction
   : process.env.STRIPE_TEST_PUBLISHABLE_KEY!
 
 // Get the correct webhook secret based on the environment
-export const webhookSecret = isProduction
+const webhookSecret = isProduction
   ? process.env.STRIPE_LIVE_WEBHOOK_SECRET!
   : process.env.STRIPE_TEST_WEBHOOK_SECRET!
 
@@ -30,13 +30,21 @@ if (!stripeSecretKey) {
 export const stripe = new Stripe(stripeSecretKey)
 
 if (!stripePublishableKey) {
-  throw new Error(`Stripe ${STRIPE_MODE} Mode: publishable key is not configured`)
+  throw new Error(
+    `${process.env.NODE_ENV}:\n  Stripe ${STRIPE_MODE} Mode: publishable key is not configured`
+  )
 }
 
 export const stripePromise = loadStripe(stripePublishableKey)
 
-export const STRIPE_CONFIG = {
-  mode: STRIPE_MODE,
-  publishableKey: stripePublishableKey,
-  webhookSecret,
-} as const
+export async function getStripeConfig() {
+  const isProduction = process.env.NODE_ENV === 'production'
+  const STRIPE_MODE = isProduction ? 'live' : 'test'
+
+  const STRIPE_CONFIG = {
+    mode: STRIPE_MODE,
+    webhookSecret,
+  } as const
+
+  return STRIPE_CONFIG
+}

--- a/src/app/(frontend)/(aet-app)/utils/stripe/session.tsx
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/session.tsx
@@ -1,7 +1,8 @@
 'use server'
 
 import { getServerSideURL } from '@/utilities/getURL'
-import { stripe, getStripeConfig } from './config'
+import { Stripe } from 'stripe'
+import { getStripeConfig } from './config'
 
 interface NewSessionOptions {
   priceId: string
@@ -10,6 +11,8 @@ interface NewSessionOptions {
 
 export const postStripeSession = async ({ priceId, applicationId }: NewSessionOptions) => {
   const stripeConfig = await getStripeConfig()
+  const stripe = new Stripe(stripeConfig.secretKey)
+
   try {
     const currentUrl = getServerSideURL()
     const returnUrl = `${currentUrl}/checkout/return?session_id={CHECKOUT_SESSION_ID}`

--- a/src/app/(frontend)/(aet-app)/utils/stripe/session.tsx
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/session.tsx
@@ -1,7 +1,7 @@
 'use server'
 
 import { getServerSideURL } from '@/utilities/getURL'
-import { stripe, STRIPE_CONFIG } from './config'
+import { stripe, getStripeConfig } from './config'
 
 interface NewSessionOptions {
   priceId: string
@@ -9,6 +9,7 @@ interface NewSessionOptions {
 }
 
 export const postStripeSession = async ({ priceId, applicationId }: NewSessionOptions) => {
+  const stripeConfig = await getStripeConfig()
   try {
     const currentUrl = getServerSideURL()
     const returnUrl = `${currentUrl}/checkout/return?session_id={CHECKOUT_SESSION_ID}`
@@ -33,13 +34,13 @@ export const postStripeSession = async ({ priceId, applicationId }: NewSessionOp
       throw new Error('No client secret returned from Stripe')
     }
 
-    console.log(`${STRIPE_CONFIG.mode} session created:`, session)
+    console.log(`${stripeConfig.mode} session created:`, session)
 
     return {
       clientSecret: session.client_secret,
     }
   } catch (error) {
-    console.error(`${STRIPE_CONFIG.mode} error creating session:`, error)
+    console.error(`${stripeConfig.mode} error creating session:`, error)
     throw new Error('Failed to create payment session')
   }
 }


### PR DESCRIPTION
- Remove server-side STRIPE_CONFIG import in InlinePricing component
- Use NODE_ENV for test mode detection in client-side code
- Modify Stripe config to export STRIPE_MODE and webhookSecret separately
- Improve error messages for Stripe key configuration
- Ensure proper separation of server and client-side Stripe configurations