### PR TITLE
feat: Add US bank account as Stripe payment method

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
@@ -17,7 +17,8 @@ export async function POST(request: Request) {
 
     // Create inline price and checkout session
     const session = await stripe.checkout.sessions.create({
-      payment_method_types: ['card', 'alipay'],
+      payment_method_types: ['card', 'alipay', 'us_bank_account'],
+      // customer: 'hi',
       line_items: [
         {
           price_data: {


### PR DESCRIPTION
- Expand Stripe payment method types to include 'us_bank_account'
- Prepare for broader payment options in checkout session creation