### PR TITLE
feat: Set default values for ApplicationForm and FCEApplicationForm

### DIFF
--- a/src/app/(frontend)/(aet-app)/components/ApplicationForm/index.tsx
+++ b/src/app/(frontend)/(aet-app)/components/ApplicationForm/index.tsx
@@ -76,6 +76,10 @@ export default function ApplicationForm() {
           },
         },
       ],
+      // Set default service type 'customizedService' as required
+      serviceType: {
+        customizedService: { required: true },
+      },
     },
   })
 

--- a/src/app/(frontend)/(aet-app)/components/FCEApplicationForm/index.tsx
+++ b/src/app/(frontend)/(aet-app)/components/FCEApplicationForm/index.tsx
@@ -58,6 +58,8 @@ export default function FCEApplicationForm() {
     resolver: zodResolver(formSchema),
     defaultValues: {
       ...(formData as FormData),
+      // Set default purpose to 'evaluation'
+      purpose: 'evaluation',
       deliveryMethod: formData?.deliveryMethod || 'no_delivery_needed',
       additionalServices: formData?.additionalServices || [],
       additionalServicesQuantity: formData?.additionalServicesQuantity || {
@@ -76,8 +78,14 @@ export default function FCEApplicationForm() {
           },
         },
       ],
+      // Set default service type 'customizedService' as required
+      serviceType: {
+        customizedService: { required: true },
+      },
     },
   })
+
+  console.log('formData', formData)
 
   // Initialize form with persisted data - ONLY ON MOUNT
   useEffect(() => {


### PR DESCRIPTION
- Add default service type 'customizedService' as required in both ApplicationForm and FCEApplicationForm components.
- Set default purpose to 'evaluation' in FCEApplicationForm for improved form handling.