### PR TITLE
fix: Update Stripe payment calculation to reflect accurate fee structure

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/create-payment/route.ts
@@ -11,8 +11,10 @@ export async function POST(request: Request) {
   try {
     const body = await request.json()
     const { amount, currency, applicationId } = body
-    const stripeFee = amount * 0.03
-    const totalAmount = amount + stripeFee
+
+    // Calculate Stripe Fee (2.9% + $0.30)
+    const totalAmount = (amount + 0.3) / (1 - 0.029)
+    const stripeFee = totalAmount - amount
 
     // Convert amount to cents and ensure it's a valid integer
     const unitAmount = Math.round(totalAmount * 100)
@@ -32,7 +34,7 @@ export async function POST(request: Request) {
             currency: currency,
             product_data: {
               name: 'Customized Service Payment',
-              description: `Price: ${amount.toFixed(2)} + Service fee: ${stripeFee.toFixed(2)}`,
+              description: `Price: ${amount.toFixed(2)} + Stripe Fee: ${stripeFee.toFixed(2)}`,
             },
             unit_amount: unitAmount, // Use rounded integer amount
           },


### PR DESCRIPTION
- Adjusted the calculation of the total amount to include the correct Stripe fee (2.9% + $0.30).
- Updated the payment description to clarify the fee as "Stripe Fee" instead of "Service fee".