### PR TITLE
fix: Update Stripe webhook session logging to handle missing applicat…

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
         const session = event.data.object as Stripe.Checkout.Session
 
         console.log('Session data:', {
-          client_reference_id: session.client_reference_id,
+          client_reference_id: session.client_reference_id || session.metadata?.applicationId,
           payment_intent: session.payment_intent,
         })
 


### PR DESCRIPTION
…ionId

- Modified the logging of the client_reference_id in the Stripe webhook to fallback to session.metadata?.applicationId if client_reference_id is not available. This change improves the robustness of session data handling during webhook events.