### PR TITLE
refactor: Comment out email notification logic in Stripe webhook route

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
@@ -84,20 +84,20 @@ export async function POST(req: Request) {
         }
 
         // Send email to the applicant
-        const estimatedCompletionDate = getEstimatedCompletionDate(applicationData)
-        const { success: emailSuccess, message: sendEmailMessage } =
-          await sendPaymentConfirmationEmail(
-            applicationId,
-            applicationData,
-            session.amount_total?.toString() || '0',
-            session.payment_intent as string,
-            estimatedCompletionDate
-          )
+        // const estimatedCompletionDate = getEstimatedCompletionDate(applicationData)
+        // const { success: emailSuccess, message: sendEmailMessage } =
+        //   await sendPaymentConfirmationEmail(
+        //     applicationId,
+        //     applicationData,
+        //     session.amount_total?.toString() || '0',
+        //     session.payment_intent as string,
+        //     estimatedCompletionDate
+        //   )
 
-        if (!emailSuccess) {
-          console.error('Failed to send payment confirmation email:', sendEmailMessage)
-          throw new Error('Failed to send payment confirmation email')
-        }
+        // if (!emailSuccess) {
+        //   console.error('Failed to send payment confirmation email:', sendEmailMessage)
+        //   throw new Error('Failed to send payment confirmation email')
+        // }
 
         return new NextResponse('Webhook processed', { status: 200 })
       }


### PR DESCRIPTION
- Temporarily disabled the email notification functionality in the Stripe webhook route to streamline processing.
- Retained the structure for future reimplementation while ensuring the webhook continues to function correctly.