### PR TITLE
fix: Initialize dayjs UTC plugin for proper timezone handling

### DIFF
--- a/src/app/(frontend)/(aet-app)/components/Email/templates/PaymentConfirmation/PaymentConfirmationEmail.tsx
+++ b/src/app/(frontend)/(aet-app)/components/Email/templates/PaymentConfirmation/PaymentConfirmationEmail.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 
 import {
   Body,
@@ -21,7 +22,14 @@ import { styles, colors } from '../../styles/config'
 
 import { ApplicationData } from '../../../FCEApplicationForm/types'
 
-// enable timezone plugin
+/**
+ * Initialize dayjs plugins in the correct order:
+ * 1. UTC plugin must be initialized first as it provides the base functionality for timezone handling
+ * 2. Timezone plugin depends on UTC plugin for timezone conversions
+ * This order is crucial for proper timezone handling in the email template,
+ * especially when formatting dates for different time zones (e.g., 'America/New_York')
+ */
+dayjs.extend(utc)
 dayjs.extend(timezone)
 
 interface PaymentConfirmationEmailProps {

--- a/src/app/(frontend)/(aet-app)/components/FCEApplicationForm/utils.ts
+++ b/src/app/(frontend)/(aet-app)/components/FCEApplicationForm/utils.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
 import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 
 import { EVALUATION_SERVICES, DELIVERY_OPTIONS, ADDITIONAL_SERVICES } from './constants'
 import {
@@ -15,8 +16,17 @@ import {
   AdditionalService,
 } from './types'
 
+// Initialize dayjs plugins
 dayjs.extend(customParseFormat)
 dayjs.extend(isSameOrBefore)
+/**
+ * Initialize dayjs plugins in the correct order:
+ * 1. UTC plugin must be initialized first as it provides the base functionality for timezone handling
+ * 2. Timezone plugin depends on UTC plugin for timezone conversions
+ * This order is crucial for proper timezone handling in the email template,
+ * especially when formatting dates for different time zones (e.g., 'America/New_York')
+ */
+dayjs.extend(utc)
 dayjs.extend(timezone)
 
 export const dateUtils = {


### PR DESCRIPTION
- Added the UTC plugin to dayjs initialization in both PaymentConfirmationEmail and FCEApplicationForm utils for accurate timezone conversions.
- Updated comments to clarify the importance of plugin initialization order for date formatting in email templates.