### PR TITLE
fix: Correct payment date property in PaymentConfirmationEmail component

### DIFF
--- a/src/app/(frontend)/(aet-app)/components/Email/templates/PaymentConfirmation/PaymentConfirmationEmail.tsx
+++ b/src/app/(frontend)/(aet-app)/components/Email/templates/PaymentConfirmation/PaymentConfirmationEmail.tsx
@@ -157,8 +157,8 @@ PaymentConfirmationEmail.PreviewProps = {
   application: {
     firstName: 'John',
     lastName: 'Doe',
-    paid_at: '2023-01-01',
   },
+  paidAt: '2023-01-01',
   paymentAmount: '100.00',
   paymentId: '1234567890',
 } as PaymentConfirmationEmailProps

--- a/src/app/(frontend)/(aet-app)/components/Email/templates/PaymentConfirmation/preview.tsx
+++ b/src/app/(frontend)/(aet-app)/components/Email/templates/PaymentConfirmation/preview.tsx
@@ -62,6 +62,7 @@ export default function Preview() {
     <PaymentConfirmationEmail
       applicationId={applicationId}
       application={previewData}
+      paidAt={paymentDate}
       paymentAmount={paymentAmount}
       paymentId={transactionId}
       estimatedCompletionDate={estimatedCompletionDate}


### PR DESCRIPTION
- Updated the payment date property from `paid_at` to `paidAt` in the PaymentConfirmationEmail component for consistency with naming conventions and improved readability.