### PR TITLE
feat: Implement scheduled workflow to check for expired applications

### DIFF
--- a/.github/workflows/check-expired-applications.yml
+++ b/.github/workflows/check-expired-applications.yml
@@ -1,0 +1,17 @@
+name: Check Expired Applications
+
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  check-expired:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for expired applications
+        run: |
+          curl -X POST "${{ secrets.API_URL }}/api/supabase/check-expired" \
+            -H "Authorization: Bearer ${{ secrets.API_KEY }}"

--- a/src/app/(frontend)/(aet-app)/components/StatusCheck/utils.ts
+++ b/src/app/(frontend)/(aet-app)/components/StatusCheck/utils.ts
@@ -16,7 +16,7 @@ export const formatUUID = (input: string): string => {
   return `${cleaned.slice(0, 8)}-${cleaned.slice(8, 12)}-${cleaned.slice(12, 16)}-${cleaned.slice(16, 20)}-${cleaned.slice(20, 32)}`
 }
 
-const PAYMENT_DEADLINE = 48 // 48 hours
+export const PAYMENT_DEADLINE = 48 // 48 hours
 /**
  * Get the payment deadline for an application
  * @param submittedAt - The date and time the application was submitted


### PR DESCRIPTION
- Added a GitHub Actions workflow that runs every hour to check for expired applications.
- Created a new API route to handle the logic for identifying and updating expired applications based on payment status and submission time.
- Exported the PAYMENT_DEADLINE constant for use in the new route, ensuring consistent application of the deadline logic.