### PR TITLE
fix: Update API URL and authorization in check-expired workflow

### DIFF
--- a/.github/workflows/check-expired-applications.yml
+++ b/.github/workflows/check-expired-applications.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Check for expired applications
         run: |
           # Store URL parts
-          BASE_URL="${{ secrets.API_URL }}"
-          API_PATH="/api/supabase/check-expired/"
+          BASE_URL="https://app.americantranslationservice.com"
+          API_PATH="/api/supabase/check-expired"
           FULL_URL="${BASE_URL}${API_PATH}"
 
           echo "Starting check-expired job..."
@@ -24,7 +24,7 @@ jobs:
 
           # Add -v for verbose output and -L to follow redirects
           response=$(curl -X POST "${FULL_URL}" \
-            -H "Authorization: Bearer ${{ secrets.API_KEY }}" \
+            -H "Authorization: Bearer 0Syjdv2O/gEE29daYYHOq+hmSoRTRq5odOLBuGotJLA1" \
             -H "Content-Type: application/json" \
             -w "\n%{http_code}" \
             -v \


### PR DESCRIPTION
- Changed the BASE_URL to a hardcoded value for the check-expired workflow.
- Updated the API_KEY in the authorization header to a specific value for testing purposes.
- These changes aim to ensure the workflow functions correctly with the new API endpoint.