### PR TITLE
chore: Update BASE_URL in check-expired workflow to use secret

### DIFF
--- a/.github/workflows/check-expired-applications.yml
+++ b/.github/workflows/check-expired-applications.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check for expired applications
         run: |
           # Store URL parts
-          BASE_URL="https://app.americantranslationservice.com"
+          BASE_URL="${{ secrets.API_URL }}"
           API_PATH="/api/supabase/check-expired"
           FULL_URL="${BASE_URL}${API_PATH}"
 


### PR DESCRIPTION
- Changed the BASE_URL in the check-expired workflow from a hardcoded value to a secret variable for improved security and flexibility.
- This update ensures that sensitive information is not exposed in the workflow configuration.