### PR TITLE
fix: Refine Stripe fee calculation in webhook handling

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
@@ -67,12 +67,13 @@ export async function POST(req: Request) {
 
         // Update the application status and payment status
         const paidAt = new Date().toISOString()
-        const stripeFee = session.amount_total * 0.029 + 30
-        const price = session.amount_total / 100 - stripeFee
+        const amountTotal = session.amount_total / 100
+        const stripeFee = amountTotal * 0.029 + 30
+        const price = amountTotal - stripeFee
 
         const currentAmount = applicationData.due_amount
         console.log('currentAmount', currentAmount)
-        console.log('session.amount_total/100', session.amount_total / 100)
+        console.log('amountTotal', amountTotal)
         console.log('stripeFee', stripeFee)
         console.log('price', price)
 


### PR DESCRIPTION
- Adjusted the calculation of the Stripe fee to improve accuracy by first converting the total amount to dollars.
- Enhanced logging to provide clearer insights into the payment processing details, including the updated amount total and calculated fees.