### PR TITLE
fix: Improve accuracy of Stripe fee calculation in webhook

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
@@ -68,8 +68,8 @@ export async function POST(req: Request) {
         // Update the application status and payment status
         const paidAt = new Date().toISOString()
         const amountTotal = session.amount_total / 100
-        const stripeFee = amountTotal * 0.029 + 30
-        const price = amountTotal - stripeFee
+        const stripeFee = Number((amountTotal * 0.029 + 0.3).toFixed(2))
+        const price = Number((amountTotal - stripeFee).toFixed(2))
 
         const currentAmount = applicationData.due_amount
         console.log('currentAmount', currentAmount)


### PR DESCRIPTION
- Refined the calculation of the Stripe fee by ensuring the result is rounded to two decimal places for better precision.
- Updated the price calculation to reflect the adjusted fee accurately, enhancing the overall payment processing logic.