### PR TITLE
feat: Set default sorting for ApplicationsTable to 'created_at' in us…

### DIFF
--- a/src/app/(frontend)/(aet-app)/components/ApplicationsTable/hooks/useTableConfig.ts
+++ b/src/app/(frontend)/(aet-app)/components/ApplicationsTable/hooks/useTableConfig.ts
@@ -36,7 +36,12 @@ interface TableConfigProps {
  */
 export const useTableConfig = ({ applications, getColumns, columnArgs }: TableConfigProps) => {
   // Table state
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: 'created_at',
+      desc: true,
+    },
+  ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [globalFilter, setGlobalFilter] = useState('')
 
@@ -67,6 +72,12 @@ export const useTableConfig = ({ applications, getColumns, columnArgs }: TableCo
       pagination: {
         pageSize: 100,
       },
+      sorting: [
+        {
+          id: 'created_at',
+          desc: true,
+        },
+      ],
     },
   })
 


### PR DESCRIPTION
…eTableConfig

- Initialized the sorting state in useTableConfig to default to 'created_at' in descending order, improving the initial data presentation in the ApplicationsTable.
- Updated the table configuration to reflect the new default sorting behavior, enhancing user experience when viewing applications.