### PR TITLE
refactor: Rename application email fetching function for clarity

### DIFF
--- a/src/app/(frontend)/(aet-app)/utils/actions.tsx
+++ b/src/app/(frontend)/(aet-app)/utils/actions.tsx
@@ -8,10 +8,10 @@ import { formatUtils as DegreeEquivalencyFormatUtils } from '../components/Degre
 import { sendApplicationConfirmationEmail } from './email/actions'
 import { Application } from '../components/ApplicationsTable/types'
 
-export async function getApplicationEmail(applicationId: string) {
+export async function getFCEApplicationEmail(applicationId: string) {
   const client = await createClient()
   const { data: application, error: applicationError } = await client
-    .from('aet_core_applications')
+    .from('fce_applications')
     .select('email')
     .eq('id', applicationId)
     .single()

--- a/src/app/(frontend)/(aet-app)/utils/stripe/actions.tsx
+++ b/src/app/(frontend)/(aet-app)/utils/stripe/actions.tsx
@@ -1,5 +1,5 @@
 import { getClientSideURL } from '@/utilities/getURL'
-import { getApplicationEmail } from '../actions'
+import { getFCEApplicationEmail } from '../actions'
 
 export async function createPayment({
   amount,
@@ -16,7 +16,7 @@ export async function createPayment({
   const baseUrl = getClientSideURL()
   const apiUrl = `${baseUrl}/api/stripe/create-payment`
 
-  const applicationEmail = await getApplicationEmail(applicationId)
+  const applicationEmail = await getFCEApplicationEmail(applicationId)
 
   try {
     const response = await fetch(apiUrl, {


### PR DESCRIPTION
- Updated the function name from getApplicationEmail to getFCEApplicationEmail to better reflect its purpose in fetching emails from the fce_applications table.
- Adjusted the createPayment function to utilize the renamed function, ensuring consistency in email retrieval for payment processing.