### PR TITLE
fix: Update application_id to null for database insertion in Stripe API

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/create-payment-link/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/create-payment-link/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: Request) {
     const client = await createClient()
     const { data, error } = await client.from('aet_core_payments').insert({
       payment_id: description,
-      application_id: applicationId || '',
+      application_id: applicationId || null,
       due_amount: amount,
       payment_status: 'pending',
       source: 'Stripe Payment Link',


### PR DESCRIPTION
- Changed the default value of application_id from an empty string to null during the payment link insertion process.
- This adjustment ensures better data integrity and consistency in the database for payment records.