### PR TITLE
fix: Correct applicationId key in Stripe webhook payment insertion

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
+++ b/src/app/(frontend)/(aet-app)/api/stripe/webhook/route.ts
@@ -159,7 +159,7 @@ export async function POST(req: Request) {
               .eq('id', applicationId)
 
             const { error: paymentError } = await client.from('aet_core_payments').insert({
-              applicationId: applicationId,
+              application_id: applicationId,
               due_amount: price,
               payment_status: 'paid',
               paid_at: new Date().toISOString(),


### PR DESCRIPTION
- Updated the key from 'applicationId' to 'application_id' in the Stripe webhook route to ensure consistency with database schema.
- This change enhances data integrity during payment processing for applications.