### PR TITLE
fix: Adjust CHUNK_SIZE for Dropbox file uploads

### DIFF
--- a/src/app/(frontend)/(aet-app)/utils/dropbox/config.client.ts
+++ b/src/app/(frontend)/(aet-app)/utils/dropbox/config.client.ts
@@ -1,5 +1,5 @@
 export const MAX_FILE_SIZE = 50 * 1024 * 1024 // 50MB
-export const CHUNK_SIZE = 4 * 1024 * 1024 // 4MB chunks to stay under Vercel's 4.5MB limit
+export const CHUNK_SIZE = 3 * 1024 * 1024 // 3MB chunks to stay under Vercel's 4.5MB limit (base64 encoding increases size by ~33%)
 export const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'application/pdf', '.doc', '.docx']
 
 export function getOfficeTokenType(officeName: string) {


### PR DESCRIPTION
- Updated the CHUNK_SIZE constant from 4MB to 3MB to accommodate base64 encoding size increase, ensuring compliance with Vercel's 4.5MB limit for chunked uploads.