### PR TITLE
refactor: Update chunk size handling for Dropbox uploads

### DIFF
--- a/src/app/(frontend)/(aet-app)/api/dropbox/chunked-upload/route.tsx
+++ b/src/app/(frontend)/(aet-app)/api/dropbox/chunked-upload/route.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { DROPBOX_TOKENS } from '../../../utils/dropbox/config.server'
-import { getOfficeTokenType } from '../../../utils/dropbox/config.client'
+import { getOfficeTokenType, CHUNK_SIZE } from '../../../utils/dropbox/config.client'
 import { getAccessToken, createDropboxClient } from '../../../utils/dropbox/server'
 
 // Store upload sessions in memory (in production, use Redis or database)
@@ -64,7 +64,7 @@ async function startUploadSession(data: {
 
   const folderPath = `${basePath}/${office}/${fullName} - ${applicationId}`
   const filePath = `${folderPath}/${fileName}`
-  const totalChunks = Math.ceil(fileSize / (4 * 1024 * 1024)) // 4MB chunks
+  const totalChunks = Math.ceil(fileSize / CHUNK_SIZE) // Use configured chunk size
 
   const accessToken = await getAccessToken(tokenType)
   const dbx = createDropboxClient(accessToken, namespaceId)

--- a/src/app/(frontend)/(aet-app)/components/Dropbox/ChunkedUploadTest.tsx
+++ b/src/app/(frontend)/(aet-app)/components/Dropbox/ChunkedUploadTest.tsx
@@ -72,9 +72,9 @@ export default function ChunkedUploadTest() {
         )}
 
         <div className="text-xs text-gray-500">
-          <p>• 文件大于 4MB 将使用分片上传</p>
-          <p>• 文件小于等于 4MB 将使用普通上传</p>
-          <p>• 分片大小: 4MB (符合 Vercel 4.5MB 限制)</p>
+          <p>• 文件大于 {(CHUNK_SIZE / 1024 / 1024).toFixed(0)}MB 将使用分片上传</p>
+          <p>• 文件小于等于 {(CHUNK_SIZE / 1024 / 1024).toFixed(0)}MB 将使用普通上传</p>
+          <p>• 分片大小: {(CHUNK_SIZE / 1024 / 1024).toFixed(0)}MB (符合 Vercel 4.5MB 限制)</p>
         </div>
       </div>
     </div>

--- a/src/app/(frontend)/(aet-app)/components/Dropbox/Uploader.tsx
+++ b/src/app/(frontend)/(aet-app)/components/Dropbox/Uploader.tsx
@@ -242,7 +242,7 @@ export default function DropboxUploader({
           const uploadKey = `${office}-${applicationId}-${file.name}`
 
           try {
-            // Use chunked upload for files larger than 4MB, regular upload for smaller files
+            // Use chunked upload for files larger than CHUNK_SIZE, regular upload for smaller files
             if (file.size > CHUNK_SIZE) {
               return await uploadFileInChunks(file, uploadKey)
             } else {


### PR DESCRIPTION
- Replaced hardcoded chunk size of 4MB with the configurable CHUNK_SIZE constant for better maintainability.
- Updated user interface in ChunkedUploadTest component to reflect the dynamic chunk size.
- Adjusted comments in Uploader component to clarify chunked upload logic based on CHUNK_SIZE.